### PR TITLE
tcpclient.go: add TCPHandlerFromConnection

### DIFF
--- a/tcpclient.go
+++ b/tcpclient.go
@@ -41,6 +41,16 @@ func NewTCPClientHandler(address string) *TCPClientHandler {
 	return h
 }
 
+// TCPHandlerFromConnection creates a TCP handler from an existing connection.
+func TCPHandlerFromConnection(conn net.Conn) *TCPClientHandler {
+	h := &TCPClientHandler{}
+	h.conn = conn
+	h.Address = conn.RemoteAddr().String()
+	h.Timeout = tcpTimeout
+	h.IdleTimeout = tcpIdleTimeout
+	return h
+}
+
 // TCPClient creates TCP client with default handler and given connect string.
 func TCPClient(address string) Client {
 	handler := NewTCPClientHandler(address)


### PR DESCRIPTION
I have a device which "encrypts" its modbus connections. Rather than implement almost identical copies of tcpPackager and tcpTransport, it makes more sense to me to add the "encryption" layer in a net.Conn implementation that wraps a real connection. This new function allows creating a client from an already-established connection.